### PR TITLE
Add methods to handle Kafka messages with headers

### DIFF
--- a/Kafka.Consumer/KafkaConsumerService.cs
+++ b/Kafka.Consumer/KafkaConsumerService.cs
@@ -1,5 +1,6 @@
 ﻿using Confluent.Kafka;
 using Kafka.Consumer.Events;
+using System.Text;
 
 namespace Kafka.Consumer
 {
@@ -115,6 +116,57 @@ namespace Kafka.Consumer
                 // We check whether the consumeResult is null or not. If it is not null, we write the message to the console.
                 if (consumeResult != null)
                 {
+                    var orderCreatedEvent = consumeResult.Message.Value;
+
+                    Console.WriteLine($"received message : {orderCreatedEvent.UserId} - {orderCreatedEvent.OrderCode} - {orderCreatedEvent.TotalPrice}");
+                }
+                await Task.Delay(10);
+            }
+        }
+        internal async Task ConsumeComplexMessageWithIntKeyAndHeader(string topicName)
+        {
+            // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Topic name cannot be null, empty, or whitespace.", nameof(topicName));
+            }
+
+            if (!await TopicExists(topicName))
+            {
+                Console.WriteLine($"Error: Topic '{topicName}' does not exist on the Kafka server.");
+                return;
+            }
+            var config = new ConsumerConfig()
+            {
+                BootstrapServers = _bootstrapServers,
+                GroupId = "use-case-2-group-1",
+                AutoOffsetReset = AutoOffsetReset.Earliest //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
+            };
+
+
+            var consumer = new ConsumerBuilder<int, OrderCreatedEvent>(config).SetValueDeserializer(new CustomValueDesirializer<OrderCreatedEvent>()).Build();
+            consumer.Subscribe(topicName);
+
+            while (true)
+            {
+                // Consume method does not pull the messages every time it is called. It pulls the messages from the broker and stores them in the consumer object. And then we can consume them one by one. When there is no message left, it goes to the broker and pulls the messages again.
+                // when there is no message, it waits for the message for the given time in milliseconds. If there is no message in the given time, it returns null.
+                var consumeResult = consumer.Consume(5000);
+
+                // We check whether the consumeResult is null or not. If it is not null, we write the message to the console.
+                if (consumeResult != null)
+                {
+                    // We can get the values of the headers by using the name of the header. 
+                    var correlationId = Encoding.UTF8.GetString(consumeResult.Message.Headers.GetLastBytes("correlationId"));
+
+                    var version = Encoding.UTF8.GetString(consumeResult.Message.Headers.GetLastBytes("version"));
+
+                    // We can also get the values of the headers by using the index of the header.
+                    //var correlationId2 = consumeResult.Message.Headers[0].GetValueBytes();
+
+                    //var version2 = consumeResult.Message.Headers[1].GetValueBytes();
+
+
                     var orderCreatedEvent = consumeResult.Message.Value;
 
                     Console.WriteLine($"received message : {orderCreatedEvent.UserId} - {orderCreatedEvent.OrderCode} - {orderCreatedEvent.TotalPrice}");

--- a/Kafka.Consumer/Program.cs
+++ b/Kafka.Consumer/Program.cs
@@ -9,7 +9,7 @@ try
     var kafkaService = new KafkaConsumerService();
 
     // we have 3 partitions and 1 replication factor for the topic. So, we can run 3 consumers at the same time and each consumer will consume messages from a different partition. But if we run more than 3 consumers, some of them will be idle because we have only 3 partitions.
-    await kafkaService.ConsumeComplexMessageWithIntKey(topicName);
+    await kafkaService.ConsumeComplexMessageWithIntKeyAndHeader(topicName);
 }
 catch (ArgumentException ex)
 {

--- a/Kafka.Producer/KafkaProducerService.cs
+++ b/Kafka.Producer/KafkaProducerService.cs
@@ -137,6 +137,48 @@ namespace Kafka.Producer
                 await Task.Delay(10);
             }
         }
+        internal async Task SendComplexMessageWithIntKeyAndHeader(string topicName)
+        {
+            var config = new ProducerConfig()
+            {
+                BootstrapServers = "localhost:9094"
+            };
+
+            // We use the CustomValueSerializer class to serialize the OrderCreatedEvent object. We use the SetValueSerializer method to set the serializer for the value of the message.
+            using var producer = new ProducerBuilder<int, OrderCreatedEvent>(config)
+                .SetValueSerializer(new CustomValueSerializer<OrderCreatedEvent>())
+                .Build();
+
+            foreach (var item in Enumerable.Range(1, 3))
+            {
+                // once we created a record object, we cannot change its properties. It is immutable. That is why we use the "with" keyword to create a new object with the new values that has different reference on the memory from the original object.
+                var orderCreatedEvent = new OrderCreatedEvent()
+                { OrderCode = Guid.NewGuid().ToString(), TotalPrice = item * 200, UserId = item };
+
+                var header = new Headers
+                {
+                    {"correlationId", Encoding.UTF8.GetBytes("123") },
+                    {"version", Encoding.UTF8.GetBytes("v1") }
+                };
+
+                var message = new Message<int, OrderCreatedEvent>()
+                {
+                    Value = orderCreatedEvent,
+                    Key = item,
+                    Headers = header
+                };
+
+                var result = await producer.ProduceAsync(topicName, message);
+
+                foreach (var propertyInfo in result.GetType().GetProperties())
+                {
+                    Console.WriteLine($"{propertyInfo.Name} : {propertyInfo.GetValue(result)}");
+                }
+
+                Console.WriteLine("---------------------------------");
+                await Task.Delay(10);
+            }
+        }
 
     }
 }

--- a/Kafka.Producer/Program.cs
+++ b/Kafka.Producer/Program.cs
@@ -9,7 +9,7 @@ Console.WriteLine("Kafka Producer");
 var kafkaService = new KafkaProducerService();
 var topicName = "use-case-3-topic";
 await kafkaService.CreateTopicAsync(topicName);
-await kafkaService.SendComplexMessageWithIntKey(topicName);
+await kafkaService.SendComplexMessageWithIntKeyAndHeader(topicName);
 
 Console.WriteLine("Messages are sent to the Kafka server.");
 


### PR DESCRIPTION
Introduced `ConsumeComplexMessageWithIntKeyAndHeader` in `KafkaConsumerService.cs` for consuming messages with integer keys and headers, including topic validation, existence check, consumer configuration, and message consumption with header reading. Updated `Program.cs` to use this new method.

Added `SendComplexMessageWithIntKeyAndHeader` in `KafkaProducerService.cs` for sending messages with integer keys and headers, including producer configuration, message creation with headers, and result printing. Updated `Program.cs` to use this new method.

Replaced existing methods for handling messages without headers with the new methods in `Program.cs`.