### PR TITLE
Add timestamp handling to Kafka consumer and producer

### DIFF
--- a/Kafka.Consumer/KafkaConsumerService.cs
+++ b/Kafka.Consumer/KafkaConsumerService.cs
@@ -139,7 +139,7 @@ namespace Kafka.Consumer
             var config = new ConsumerConfig()
             {
                 BootstrapServers = _bootstrapServers,
-                GroupId = "use-case-2-group-1",
+                GroupId = "use-case-3-group-1",
                 AutoOffsetReset = AutoOffsetReset.Earliest //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
             };
 
@@ -170,7 +170,6 @@ namespace Kafka.Consumer
                 await Task.Delay(10);
             }
         }
-
         internal async Task ConsumeComplexMessageWithIntKeyAndHeader(string topicName)
         {
             // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
@@ -187,7 +186,7 @@ namespace Kafka.Consumer
             var config = new ConsumerConfig()
             {
                 BootstrapServers = _bootstrapServers,
-                GroupId = "use-case-2-group-1",
+                GroupId = "use-case-3-group-1",
                 AutoOffsetReset = AutoOffsetReset.Earliest //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
             };
 
@@ -218,6 +217,47 @@ namespace Kafka.Consumer
                     var orderCreatedEvent = consumeResult.Message.Value;
 
                     Console.WriteLine($"received message : {orderCreatedEvent.UserId} - {orderCreatedEvent.OrderCode} - {orderCreatedEvent.TotalPrice}");
+                }
+                await Task.Delay(10);
+            }
+        }
+        internal async Task ConsumeMessageWithTimestamp(string topicName)
+        {
+            // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Topic name cannot be null, empty, or whitespace.", nameof(topicName));
+            }
+
+            if (!await TopicExists(topicName))
+            {
+                Console.WriteLine($"Error: Topic '{topicName}' does not exist on the Kafka server.");
+                return;
+            }
+            var config = new ConsumerConfig()
+            {
+                BootstrapServers = _bootstrapServers,
+                GroupId = "use-case-3-group-1",
+                AutoOffsetReset = AutoOffsetReset.Earliest //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
+            };
+
+
+            var consumer = new ConsumerBuilder<MessageKey, OrderCreatedEvent>(config)
+                .SetValueDeserializer(new CustomValueDesirializer<OrderCreatedEvent>())
+                .SetKeyDeserializer(new CustomKeyDesirializer<MessageKey>())
+                .Build();
+            consumer.Subscribe(topicName);
+
+            while (true)
+            {
+                // Consume method does not pull the messages every time it is called. It pulls the messages from the broker and stores them in the consumer object. And then we can consume them one by one. When there is no message left, it goes to the broker and pulls the messages again.
+                // when there is no message, it waits for the message for the given time in milliseconds. If there is no message in the given time, it returns null.
+                var consumeResult = consumer.Consume(5000);
+
+                // We check whether the consumeResult is null or not. If it is not null, we write the message to the console.
+                if (consumeResult != null)
+                {
+                    Console.WriteLine($"Message Timestamp : {consumeResult.Message.Timestamp.UtcDateTime}");
                 }
                 await Task.Delay(10);
             }

--- a/Kafka.Consumer/Program.cs
+++ b/Kafka.Consumer/Program.cs
@@ -9,7 +9,7 @@ try
     var kafkaService = new KafkaConsumerService();
 
     // we have 3 partitions and 1 replication factor for the topic. So, we can run 3 consumers at the same time and each consumer will consume messages from a different partition. But if we run more than 3 consumers, some of them will be idle because we have only 3 partitions.
-    await kafkaService.ConsumeComplexMessageWithComplexKey(topicName);
+    await kafkaService.ConsumeMessageWithTimestamp(topicName);
 }
 catch (ArgumentException ex)
 {

--- a/Kafka.Producer/Program.cs
+++ b/Kafka.Producer/Program.cs
@@ -9,7 +9,7 @@ Console.WriteLine("Kafka Producer");
 var kafkaService = new KafkaProducerService();
 var topicName = "use-case-3-topic";
 await kafkaService.CreateTopicAsync(topicName);
-await kafkaService.SendComplexMessageWithComplexKey(topicName);
+await kafkaService.SendMessageWithTimestamp(topicName);
 
 Console.WriteLine("Messages are sent to the Kafka server.");
 


### PR DESCRIPTION
Updated GroupId in KafkaConsumerService.cs to "use-case-3-group-1". Removed methods for complex messages with int key and header. Added methods for handling messages with timestamps. Replaced method calls in Program.cs to use new timestamp methods. Configured KafkaProducerService.cs to use LogAppendTime for timestamps.