### PR TITLE
Update Kafka services to handle specified partitions

### DIFF
--- a/Kafka.Consumer/KafkaConsumerService.cs
+++ b/Kafka.Consumer/KafkaConsumerService.cs
@@ -262,6 +262,46 @@ namespace Kafka.Consumer
                 await Task.Delay(10);
             }
         }
+        internal async Task ConsumeMessageFromSpecifiedPartition(string topicName)
+        {
+            // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Topic name cannot be null, empty, or whitespace.", nameof(topicName));
+            }
+
+            if (!await TopicExists(topicName))
+            {
+                Console.WriteLine($"Error: Topic '{topicName}' does not exist on the Kafka server.");
+                return;
+            }
+            var config = new ConsumerConfig()
+            {
+                BootstrapServers = _bootstrapServers,
+                GroupId = "use-case-4-group-1",
+                AutoOffsetReset = AutoOffsetReset.Earliest //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
+            };
+
+
+            var consumer = new ConsumerBuilder<Null, string>(config).Build();
+            //consumer.Subscribe(topicName);
+            // We can consume messages from a specific partition by using the Assign method. We need to provide the topic name and the partition number as parameters.
+            consumer.Assign(new TopicPartition(topicName, new Partition(4)));
+            while (true)
+            {
+                // Consume method does not pull the messages every time it is called. It pulls the messages from the broker and stores them in the consumer object. And then we can consume them one by one. When there is no message left, it goes to the broker and pulls the messages again.
+                // when there is no message, it waits for the message for the given time in milliseconds. If there is no message in the given time, it returns null.
+                var consumeResult = consumer.Consume(5000);
+
+                // We check whether the consumeResult is null or not. If it is not null, we write the message to the console.
+                if (consumeResult != null)
+                {
+                    Console.WriteLine($"Message Timestamp : {consumeResult.Message.Timestamp.UtcDateTime}");
+                }
+                await Task.Delay(10);
+            }
+        }
+
 
 
         private async Task<bool> TopicExists(string topicName)

--- a/Kafka.Consumer/Program.cs
+++ b/Kafka.Consumer/Program.cs
@@ -5,11 +5,11 @@ Console.WriteLine("Kafka Consumer 1");
 // We added try-catch block to catch the exception if the topicName is null, empty, or whitespace.
 try
 {
-    var topicName = "use-case-3-topic";
+    var topicName = "use-case-4-topic";
     var kafkaService = new KafkaConsumerService();
 
     // we have 3 partitions and 1 replication factor for the topic. So, we can run 3 consumers at the same time and each consumer will consume messages from a different partition. But if we run more than 3 consumers, some of them will be idle because we have only 3 partitions.
-    await kafkaService.ConsumeMessageWithTimestamp(topicName);
+    await kafkaService.ConsumeMessageFromSpecifiedPartition(topicName);
 }
 catch (ArgumentException ex)
 {

--- a/Kafka.Producer/Program.cs
+++ b/Kafka.Producer/Program.cs
@@ -7,9 +7,9 @@ Console.WriteLine("Kafka Producer");
 
 
 var kafkaService = new KafkaProducerService();
-var topicName = "use-case-3-topic";
+var topicName = "use-case-4-topic";
 await kafkaService.CreateTopicAsync(topicName);
-await kafkaService.SendMessageWithTimestamp(topicName);
+await kafkaService.SendMessageToSpecifiedPartition(topicName);
 
 Console.WriteLine("Messages are sent to the Kafka server.");
 


### PR DESCRIPTION
Updated KafkaConsumerService to include ConsumeMessageFromSpecifiedPartition method for consuming messages from a specified partition. Modified Program.cs to use this new method and changed the topic name to "use-case-4-topic". Updated KafkaProducerService to create topics with 6 partitions and added SendMessageToSpecifiedPartition method. Adjusted producer's Program.cs to use the new method.