### PR TITLE
Add manual ack methods to Kafka services

### DIFF
--- a/Kafka.Consumer/KafkaConsumerService.cs
+++ b/Kafka.Consumer/KafkaConsumerService.cs
@@ -103,7 +103,7 @@ namespace Kafka.Consumer
                 AutoOffsetReset = AutoOffsetReset.Earliest //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
             };
 
-            
+
             var consumer = new ConsumerBuilder<int, OrderCreatedEvent>(config).SetValueDeserializer(new CustomValueDesirializer<OrderCreatedEvent>()).Build();
             consumer.Subscribe(topicName);
 
@@ -340,8 +340,53 @@ namespace Kafka.Consumer
                 await Task.Delay(10);
             }
         }
+        internal async Task ConsumeMessageWithAck(string topicName)
+        {
+            // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Topic name cannot be null, empty, or whitespace.", nameof(topicName));
+            }
+
+            if (!await TopicExists(topicName))
+            {
+                Console.WriteLine($"Error: Topic '{topicName}' does not exist on the Kafka server.");
+                return;
+            }
+            var config = new ConsumerConfig()
+            {
+                BootstrapServers = _bootstrapServers,
+                GroupId = "use-case-5-group-1",
+                AutoOffsetReset = AutoOffsetReset.Earliest, //If We set the offset to the earliest so that we can consume all the messages in the topic. But if we set it to the latest, we will consume only the new messages that will be produced after the consumer is started.
+                EnableAutoCommit = false // If we set the EnableAutoCommit property to true, the consumer will automatically commit the offset after consuming the message. If we set it to false, we need to commit the offset manually. Default value is true. 
+            };
 
 
+            var consumer = new ConsumerBuilder<Null, string>(config).Build();
+            consumer.Subscribe(topicName);
+            while (true)
+            {
+                // Consume method does not pull the messages every time it is called. It pulls the messages from the broker and stores them in the consumer object. And then we can consume them one by one. When there is no message left, it goes to the broker and pulls the messages again.
+                // when there is no message, it waits for the message for the given time in milliseconds. If there is no message in the given time, it returns null.
+                var consumeResult = consumer.Consume(5000);
+
+                // We check whether the consumeResult is null or not. If it is not null, we write the message to the console.
+                if (consumeResult != null)
+                {
+                    try
+                    {
+                        Console.WriteLine($"Message Timestamp : {consumeResult.Message.Value}");
+                        consumer.Commit(consumeResult); // We commit the offset after consuming the message.
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        throw;
+                    }
+                }
+                await Task.Delay(10);
+            }
+        }
 
         private async Task<bool> TopicExists(string topicName)
         {

--- a/Kafka.Consumer/Program.cs
+++ b/Kafka.Consumer/Program.cs
@@ -9,7 +9,7 @@ try
     var kafkaService = new KafkaConsumerService();
 
     // we have 3 partitions and 1 replication factor for the topic. So, we can run 3 consumers at the same time and each consumer will consume messages from a different partition. But if we run more than 3 consumers, some of them will be idle because we have only 3 partitions.
-    await kafkaService.ConsumeMessageFromSpecifiedPartitionOffset(topicName);
+    await kafkaService.ConsumeMessageWithAck(topicName);
 }
 catch (ArgumentException ex)
 {

--- a/Kafka.Producer/KafkaProducerService.cs
+++ b/Kafka.Producer/KafkaProducerService.cs
@@ -117,7 +117,7 @@ namespace Kafka.Producer
             {
                 // once we created a record object, we cannot change its properties. It is immutable. That is why we use the "with" keyword to create a new object with the new values that has different reference on the memory from the original object.
                 var orderCreatedEvent = new OrderCreatedEvent()
-                { OrderCode = Guid.NewGuid().ToString(), TotalPrice = item * 200, UserId=item};
+                { OrderCode = Guid.NewGuid().ToString(), TotalPrice = item * 200, UserId = item };
 
 
                 var message = new Message<int, OrderCreatedEvent>()
@@ -267,7 +267,7 @@ namespace Kafka.Producer
 
             foreach (var item in Enumerable.Range(1, 10))
             {
-                var message = new Message<Null,string>{ Value= $"Message {item}" };
+                var message = new Message<Null, string> { Value = $"Message {item}" };
 
 
                 // We can send the message to the specified partion. In this example, we send the message to the partition 4.
@@ -284,6 +284,36 @@ namespace Kafka.Producer
                 await Task.Delay(10);
             }
         }
+        internal async Task SendMessageWithAck(string topicName)
+        {
+            // Acknowledgement is used to confirm that the message is received by the broker. We can set the Acknowledgement type in the ProducerConfig. There are 3 types of Acknowledgement: None, Leader and All. All means that the message is received by all replicas. Leader means that the message is received by the leader replice. None means that the message is not received by any replica. None is low latency option but it is not reliable. All is the most reliable option but it is slow. Leader is the middle option between None and All. 
+            // We should set the Acknowledgement type to All in such cases like financial transactions, orders, etc. 
+            // We can set it to Leader in such cases like logging, monitoring, sending notifications or Welcome emails, etc.
+            // We can set it to None in such cases like sending telemetry data etc.
+            var config = new ProducerConfig() { BootstrapServers = "localhost:9094", Acks = Acks.All };
+
+            using var producer = new ProducerBuilder<Null, string>(config).Build();
+
+            foreach (var item in Enumerable.Range(1, 10))
+            {
+                var message = new Message<Null, string> { Value = $"Message {item}" };
+
+
+                // We can send the message to the specified partion. In this example, we send the message to the partition 4.
+                var topicPartition = new TopicPartition(topicName, new Partition(4));
+
+                var result = await producer.ProduceAsync(topicName, message);
+
+                foreach (var propertyInfo in result.GetType().GetProperties())
+                {
+                    Console.WriteLine($"{propertyInfo.Name} : {propertyInfo.GetValue(result)}");
+                }
+
+                Console.WriteLine("---------------------------------");
+                await Task.Delay(10);
+            }
+        }
+
 
 
 

--- a/Kafka.Producer/Program.cs
+++ b/Kafka.Producer/Program.cs
@@ -7,9 +7,9 @@ Console.WriteLine("Kafka Producer");
 
 
 var kafkaService = new KafkaProducerService();
-var topicName = "use-case-5-topic";
+var topicName = "ack-topic";
 await kafkaService.CreateTopicAsync(topicName);
-await kafkaService.SendMessageToSpecifiedPartition(topicName);
+await kafkaService.SendMessageWithAck(topicName);
 
 Console.WriteLine("Messages are sent to the Kafka server.");
 


### PR DESCRIPTION
Updated KafkaConsumerService.cs to include ConsumeMessageWithAck for manual acknowledgment. Modified Program.cs to use this new method. Added SendMessageWithAck to KafkaProducerService.cs for sending messages with Acks.All. Updated Program.cs to call SendMessageWithAck and changed topic name to "ack-topic". Made minor formatting improvements for readability.