### PR TITLE
Add CreateTopicWithRetentionAsync method to KafkaProducer

### DIFF
--- a/Kafka.Producer/Program.cs
+++ b/Kafka.Producer/Program.cs
@@ -7,8 +7,8 @@ Console.WriteLine("Kafka Producer");
 
 
 var kafkaService = new KafkaProducerService();
-var topicName = "ack-topic";
-await kafkaService.CreateTopicAsync(topicName);
+var topicName = "retention-topic";
+await kafkaService.CreateTopicWithRetentionAsync(topicName);
 await kafkaService.SendMessageWithAck(topicName);
 
 Console.WriteLine("Messages are sent to the Kafka server.");


### PR DESCRIPTION
Updated KafkaProducerService.cs to include CreateTopicWithRetentionAsync for creating Kafka topics with a 30-day retention period. Modified Program.cs to use this new method and changed the topic name from "ack-topic" to "retention-topic".