### PR TITLE
Update Kafka services and add cluster setup

### DIFF
--- a/Kafka.Consumer/KafkaConsumerService.cs
+++ b/Kafka.Consumer/KafkaConsumerService.cs
@@ -6,7 +6,7 @@ namespace Kafka.Consumer
 {
     internal class KafkaConsumerService
     {
-        private readonly string _bootstrapServers = "localhost:9094";
+        private readonly string _bootstrapServers = "localhost:9094,localhost:7000,localhost:7001,localhost:7002";
         internal async Task ConsumeSimpleMessageWithNullKey(string topicName)
         {
             // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
@@ -387,6 +387,51 @@ namespace Kafka.Consumer
                 await Task.Delay(10);
             }
         }
+        internal async Task ConsumeMessageFromCluster(string topicName)
+        {
+            // We check whether the topicName is null, empty, or whitespace. If it is, we throw an exception to inform the user.
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Topic name cannot be null, empty, or whitespace.", nameof(topicName));
+            }
+
+            if (!await TopicExists(topicName))
+            {
+                Console.WriteLine($"Error: Topic '{topicName}' does not exist on the Kafka server.");
+                return;
+            }
+            var config = new ConsumerConfig()
+            {
+                BootstrapServers = "localhost:7000,localhost:7001,localhost:7002",
+                GroupId = "group-x",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoCommit = false 
+            };
+
+
+            var consumer = new ConsumerBuilder<Null, string>(config).Build();
+            consumer.Subscribe(topicName);
+            while (true)
+            {
+                var consumeResult = consumer.Consume(5000);
+
+                if (consumeResult != null)
+                {
+                    try
+                    {
+                        Console.WriteLine($"Message Timestamp : {consumeResult.Message.Value}");
+                        consumer.Commit(consumeResult); 
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        throw;
+                    }
+                }
+                await Task.Delay(10);
+            }
+        }
+
 
         private async Task<bool> TopicExists(string topicName)
         {

--- a/Kafka.Consumer/Program.cs
+++ b/Kafka.Consumer/Program.cs
@@ -5,11 +5,11 @@ Console.WriteLine("Kafka Consumer 1");
 // We added try-catch block to catch the exception if the topicName is null, empty, or whitespace.
 try
 {
-    var topicName = "use-case-5-topic";
+    var topicName = "mycluster-topic-2";
     var kafkaService = new KafkaConsumerService();
 
     // we have 3 partitions and 1 replication factor for the topic. So, we can run 3 consumers at the same time and each consumer will consume messages from a different partition. But if we run more than 3 consumers, some of them will be idle because we have only 3 partitions.
-    await kafkaService.ConsumeMessageWithAck(topicName);
+    await kafkaService.ConsumeMessageFromCluster(topicName);
 }
 catch (ArgumentException ex)
 {

--- a/Kafka.Producer/Program.cs
+++ b/Kafka.Producer/Program.cs
@@ -7,9 +7,9 @@ Console.WriteLine("Kafka Producer");
 
 
 var kafkaService = new KafkaProducerService();
-var topicName = "retention-topic";
-await kafkaService.CreateTopicWithRetentionAsync(topicName);
-await kafkaService.SendMessageWithAck(topicName);
+var topicName = "mycluster-topic-2";
+await kafkaService.CreateTopicWithClusterAsync(topicName);
+await kafkaService.SendMessageToCluster(topicName);
 
 Console.WriteLine("Messages are sent to the Kafka server.");
 

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -1,0 +1,86 @@
+version: "3.8"
+
+services:
+  kafka-0:
+    image: docker.io/bitnami/kafka:3.8
+    ports:
+    - "7000:7000"
+    - "9092"
+    environment:
+        # KRaft Settings
+        - KAFKA_CFG_NODE_ID=0
+        - KAFKA_CFG_PROCESS_ROLES=controller,broker
+        - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka-0:9093,1@kafka-1:9093,2@kafka-2:9093
+        - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv 
+        # Listeners
+        - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:7000
+        - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://:9092,EXTERNAL://localhost:7000
+        - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+        - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+        - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+        # Clustering
+        - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+        - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3 
+        - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+    volumes:
+        - kafka_0_data:/bitnami/kafka
+  kafka-1:
+    image: docker.io/bitnami/kafka:3.8
+    ports:
+    - "7001:7001"
+    - "9092"
+    environment:
+        # KRaft Settings
+        - KAFKA_CFG_NODE_ID=1
+        - KAFKA_CFG_PROCESS_ROLES=controller,broker
+        - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka-0:9093,1@kafka-1:9093,2@kafka-2:9093
+        - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv 
+        # Listeners
+        - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:7001
+        - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://:9092,EXTERNAL://localhost:7001
+        - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+        - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+        - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+        # Clustering
+        - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+        - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3 
+        - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+    volumes:
+        - kafka_1_data:/bitnami/kafka
+  kafka-2:
+    image: docker.io/bitnami/kafka:3.8
+    ports:
+    - "7002:7002"
+    - "9092"
+    environment:
+        # KRaft Settings
+        - KAFKA_CFG_NODE_ID=2
+        - KAFKA_CFG_PROCESS_ROLES=controller,broker
+        - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka-0:9093,1@kafka-1:9093,2@kafka-2:9093
+        - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv 
+        # Listeners
+        - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:7002
+        - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://:9092,EXTERNAL://localhost:7002
+        - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+        - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+        - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+        # Clustering
+        - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+        - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3 
+        - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+    volumes:
+        - kafka_2_data:/bitnami/kafka
+  kafka-ui:
+    container_name: kafka-ui
+    image: provectuslabs/kafka-ui:v0.7.2
+    ports:
+        - 8080:8080
+    environment:
+      DYNAMIC_CONFIG_ENABLED: 'true'
+volumes:
+  kafka_0_data:
+    driver: local
+  kafka_1_data:
+    driver: local
+  kafka_2_data:
+    driver: local

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -7,6 +7,7 @@
     <ProjectGuid>4332f563-687c-4d5b-a312-05fd40fdacc5</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="docker-compose-cluster.yml" />
     <None Include="docker-compose.yml" />
     <None Include=".dockerignore" />
   </ItemGroup>


### PR DESCRIPTION
Updated Kafka consumer and producer services to connect to a Kafka cluster with multiple brokers. Added methods for consuming messages with error handling and manual offset commits, creating topics with specific configurations, and sending messages to the cluster. Updated `Program.cs` to use new methods and changed the topic name to `mycluster-topic-2`. Added `docker-compose-cluster.yml` for setting up a Kafka cluster with three brokers and a Kafka UI service. Updated `docker-compose.dcproj` to include the new Docker Compose file.